### PR TITLE
Question: Where is the correct source code for this n8n node?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fillout for N8N by vwork Digital
+# Instant Airtable Trigger??
 
 These are n8n community nodes for triggering workflows based on Fillout submissions, and interacting with your Fillout forms directly in N8N.
 


### PR DESCRIPTION
## Summary
- Changed README title to "Instant Airtable Trigger??" to highlight the discrepancy
- The current code appears to be for Fillout forms, not Airtable triggers
- Need clarification on the correct source code location

## Question for Repository Owner
Hi\! I noticed that this repository is named "instant-airtable-trigger-node" and is mentioned in npm, but the actual code seems to be for Fillout forms integration rather than Airtable triggers. 

Could you please clarify:
1. Where is the correct source code for the Airtable trigger node?
2. Is this repository supposed to contain different code?
3. Should the npm package point to a different repository?

This would help users find the right code for their Airtable integration needs.

🤖 Generated with [Claude Code](https://claude.ai/code)